### PR TITLE
Point to Temporal SDK search results page on Nexus

### DIFF
--- a/docs/java-quick-start.md
+++ b/docs/java-quick-start.md
@@ -12,7 +12,7 @@ To run samples locally you need to run Temporal server locally using [instructio
 
 ### Include Temporal Java SDK Dependency
 
-Go to the [Maven Repository Temporal Java Client Page](https://oss.sonatype.org/service/local/repositories/snapshots/content/io/temporal/temporal-sdk/0.10.0-SNAPSHOT/)
+Go to the [Maven Repository Temporal Java Client Page](https://oss.sonatype.org/#nexus-search;quick~temporal-sdk)
 and find the latest version of the library. Include it as a dependency into your Java project. For example if you
 are using Gradle the dependency looks like:
 ```


### PR DESCRIPTION
The old link pointed to a raw text page. My link points to the search results of `temporal-sdk` on Sonatype Nexus.