### PR TITLE
Update links to Java/Go quick starts

### DIFF
--- a/docs/installing-server.md
+++ b/docs/installing-server.md
@@ -58,6 +58,6 @@ At this point Temporal Server is running! You can also see the web interface on 
 
 ## Write Workflows and Activities using Client SDK
 
-Try out [Java SDK](java-quick-start).
+Try out [Java SDK](../java-quick-start/).
  
-Try out [Go SDK](go-quick-start). 
+Try out [Go SDK](../go-quick-start/). 


### PR DESCRIPTION
Links are broken now. If I read it correctly, `../go-quick-start/` should be correct to navigate from `https://docs.temporal.io/docs/installing-server/` to `https://docs.temporal.io/docs/go-quick-start`.