### PR TITLE
Fix broken links in configuration page.

### DIFF
--- a/docs/learn-server-configuration.md
+++ b/docs/learn-server-configuration.md
@@ -9,10 +9,10 @@ Temporal Server configuration is found in `development.yaml` and may contain the
 - [**global**](#global) 
 - [**persistence**](#persistence) 
 - [**log**](#log) 
-- [**clusterMetadata**](#clusterMetadata)
-- [**services**](#service) 
-- [**kafka**](#kafkaConfig) 
-- [**publicClient**](#publicClient) 
+- [**clusterMetadata**](#clustermetadata)
+- [**services**](#services)
+- [**kafka**](#kafka)
+- [**publicClient**](#publicclient)
 - archival
 - dcRedirectionPolicy
 - dynamicConfigClient


### PR DESCRIPTION
Fixed broken documentation links on the config page for kafka, clustermetadata, services, and public client. There were also some bullet points that are not referenced in the doc, but I left that there as I was not sure if there was a reason it was that way. 