### PR TITLE
Retry timeout updates

### DIFF
--- a/docs/go-retries.md
+++ b/docs/go-retries.md
@@ -23,13 +23,8 @@ RetryPolicy struct {
     // This value is the cap of the interval. Default is 100x of initial interval.
     MaximumInterval time.Duration
 
-    // Maximum time to retry. Either ExpirationInterval or MaximumAttempts is required.
-    // When exceeded the retries stop even if maximum retries is not reached yet.
-    ExpirationInterval time.Duration
-
     // Maximum number of attempts. When exceeded the retries stop even if not expired yet.
-    // If not set or set to 0, it means unlimited, and relies on ExpirationInterval to stop.
-    // Either MaximumAttempts or ExpirationInterval is required.
+    // If not set or set to 0, it means unlimited
     MaximumAttempts int32
 
     // Non-Retriable errors. This is optional. Temporal server will stop retry if error reason matches this list.
@@ -51,7 +46,6 @@ retryPolicy := &workflow.RetryPolicy{
     InitialInterval:    time.Second,
     BackoffCoefficient: 2,
     MaximumInterval:    expiration,
-    ExpirationInterval: time.Minute * 10,
     MaximumAttempts:    5,
 }
 ao := workflow.ActivityOptions{
@@ -93,9 +87,7 @@ you start a workflow via `StartWorkflowOptions`.
 There are some subtle changes to workflow's history events when `RetryPolicy` is used.
 For an activity with `RetryPolicy`:
 
-* The `ActivityTaskScheduledEvent` will have extended `ScheduleToStartTimeout` and `ScheduleToCloseTimeout`. These two timeouts
-  will be overwritten by the server to be as long as the retry policy's `ExpirationInterval`. If the `ExpirationInterval`
-  is not specified, it will be overwritten to the workflow's timeout.
+* The `ActivityTaskScheduledEvent` will have extended `ScheduleToStartTimeout` and `ScheduleToCloseTimeout`.
 * The `ActivityTaskStartedEvent` will not show up in history until the activity is completed or failed with no more retry.
   This is to avoid recording the `ActivityTaskStarted` event but later it failed and retried. Using the `DescribeWorkflowExecution`
   API will return the `PendingActivityInfo` and it will contain `attemptCount` if it is retrying.

--- a/docs/learn-activities.md
+++ b/docs/learn-activities.md
@@ -27,8 +27,7 @@ As Temporal doesn't recover an activity's state and they can communicate to any 
 - `InitialInterval` is a delay before the first retry.
 - `BackoffCoefficient`. Retry policies are exponential. The coefficient specifies how fast the retry interval is growing. The coefficient of 1 means that the retry interval is always equal to the `InitialInterval`.
 - `MaximumInterval` specifies the maximum interval between retries. Useful for coefficients more than 1.
-- `MaximumAttempts` specifies how many times to attempt to execute an activity in the presence of failures. If this limit is exceeded, the error is returned back to the workflow that invoked the activity. Not required if `ExpirationInterval` is specified.
-- `ExpirationInterval` specifies for how long to attempt executing an activity in the presence of failures. If this interval is exceeded, the error is returned back to the workflow that invoked the activity. Not required if `MaximumAttempts` is specified.
+- `MaximumAttempts` specifies how many times to attempt to execute an activity in the presence of failures. If this limit is exceeded, the error is returned back to the workflow that invoked the activity.
 - `NonRetryableErrorReasons` allows you to specify errors that shouldn't be retried. For example retrying invalid arguments error doesn't make sense in some scenarios.
 
 There are scenarios when not a single activity but rather the whole part of a workflow should be retried on failure. For example, a media encoding workflow that downloads a file to a host, processes it, and then uploads the result back to storage. In this workflow, if the host that hosts the worker dies, all three activities should be retried on a different host. Such retries should be handled by the workflow code as they are very use case specific.

--- a/docs/learn-workflows.md
+++ b/docs/learn-workflows.md
@@ -106,6 +106,14 @@ The main limitation of a child workflow versus collocating all the application l
 
 We recommended starting from a single workflow implementation if your problem has bounded size in terms of number of executed activities and processed signals. It is more straightforward than multiple asynchronously communicating workflows.
 
+## Workflow Timeouts
+
+It's often necessary to limit the amount of time a specific workflow can be running. To support this, the following three parameters can be provided to workflow options:
+
+- `WorkflowExecutionTimeout` maximum time a workflow should be allowed to run including retries and continue as new. Use `WorkflowRunTimeout` to limit execution time of a single run.
+- `WorkflowRunTimeout` maximum time a single workflow run should be allowed.
+- `WorkflowTaskTimeout` timeout for processing a workflow task starting from the point when a worker pulled the task. If a decision task is lost, it is retried after this timeout.
+
 ## Workflow Retries
 
 Workflow code is unaffected by infrastructure level downtime and failures. But it still can fail due to business logic level failures. For example, an activity can fail due to exceeding the retry interval and the error is not handled by application code, or the workflow code having a bug.

--- a/docs/learn-workflows.md
+++ b/docs/learn-workflows.md
@@ -115,6 +115,5 @@ Some workflows require a guarantee that they keep running even in presence of su
 - `InitialInterval` is a delay before the first retry.
 - `BackoffCoefficient`. Retry policies are exponential. The coefficient specifies how fast the retry interval is growing. The coefficient of 1 means that the retry interval is always equal to the `InitialInterval`.
 - `MaximumInterval` specifies the maximum interval between retries. Useful for coefficients of more than 1.
-- `MaximumAttempts` specifies how many times to attempt to execute a workflow in the presence of failures. If this limit is exceeded, the workflow fails without retry. Not required if `ExpirationInterval` is specified.
-- `ExpirationInterval` specifies for how long to attempt executing a workflow in the presence of failures. If this interval is exceeded, the workflow fails without retry. Not required if `MaximumAttempts` is specified.
+- `MaximumAttempts` specifies how many times to attempt to execute a workflow in the presence of failures. If this limit is exceeded, the workflow fails without retry.
 - `NonRetryableErrorReasons` allows to specify errors that shouldn't be retried. For example, retrying invalid arguments error doesn't make sense in some scenarios.


### PR DESCRIPTION
I made some updates to the docs that reflect the changes to timeouts and retries in v.23.0 alpha. Those changes are:

* Removed all references to ExpirationInterval
* Added section describing how to configure timeouts for workflows

I'm not 100% confident in the way I rephrased the retries section. Specifically I'm not sure how MaximumAttempts behavior changed with the removal of ExpirationInterval. Also not sure if this section is accurate:

```
* The `ActivityTaskScheduledEvent` will have extended `ScheduleToStartTimeout` and `ScheduleToCloseTimeout`. These two timeouts
  will be overwritten by the server to be as long as the retry policy's `ExpirationInterval`. If the `ExpirationInterval`
  is not specified, it will be overwritten to the workflow's timeout.
```
