### PR TITLE
Updated the hyperlinks of Java SDK and Go SDK

### DIFF
--- a/docs/installing-server.md
+++ b/docs/installing-server.md
@@ -58,6 +58,6 @@ At this point Temporal Server is running! You can also see the web interface on 
 
 ## Write Workflows and Activities using Client SDK
 
-Try out [Java SDK](../java-quick-start/).
+Try out [Java SDK](../docs/java-quick-start/).
  
-Try out [Go SDK](../go-quick-start/). 
+Try out [Go SDK](../docs/go-quick-start/). 


### PR DESCRIPTION
The Java SDK and Go SDK hyperlinks were directed to 404 page.